### PR TITLE
OcpiLocation object - 2.1.1 properties (validation missing)

### DIFF
--- a/src/OCPI.Net.Contracts/Location/OcpiConnector.cs
+++ b/src/OCPI.Net.Contracts/Location/OcpiConnector.cs
@@ -16,14 +16,26 @@ public class OcpiConnector
     [JsonPropertyName("power_type")]
     public PowerType? PowerType { get; set; }
 
+    //OCPI 2.1.1 property
+    [JsonPropertyName("voltage")]
+    public int? Voltage { get; set; }
+
     [JsonPropertyName("max_voltage")]
     public int? MaxVoltage { get; set; }
+
+    //OCPI 2.1.1 property
+    [JsonPropertyName("amperage")]
+    public int? Amperage { get; set; }
 
     [JsonPropertyName("max_amperage")]
     public int? MaxAmperage { get; set; }
 
     [JsonPropertyName("max_electric_power")]
     public int? MaxElectricPower { get; set; }
+
+    //OCPI 2.1.1 property
+    [JsonPropertyName("tariff_id")]
+    public string? TariffId { get; set; }
 
     [JsonPropertyName("tariff_ids")]
     public IEnumerable<string>? TariffIds { get; set; }

--- a/src/OCPI.Net.Contracts/Location/OcpiLocation.cs
+++ b/src/OCPI.Net.Contracts/Location/OcpiLocation.cs
@@ -43,6 +43,10 @@ public class OcpiLocation
     [JsonPropertyName("related_locations")]
     public IEnumerable<OcpiAdditionalGeolocation>? RelatedLocations { get; set; }
 
+    //OCPI 2.1.1 property
+    [JsonPropertyName("type")]
+    public LocationType? Type { get; set; }
+
     [JsonPropertyName("parking_type")]
     public ParkingType? ParkingType { get; set; }
 

--- a/src/OCPI.Net.Core/Enums/Location/LocationType.cs
+++ b/src/OCPI.Net.Core/Enums/Location/LocationType.cs
@@ -1,0 +1,49 @@
+﻿using System.Runtime.Serialization;
+
+namespace OCPI;
+
+public enum LocationType : byte
+{
+    /// <summary>
+    /// Parking in public space.
+    /// </summary>
+    [EnumMember(Value = "UNKNOWN")]
+    Unknown = 0,
+
+    //======================================
+
+    /// <summary>
+    /// Parking in public space.
+    /// </summary>
+    [EnumMember(Value = "ON_STREET")]
+    OnStreet = 11,
+
+    //======================================
+
+    /// <summary>
+    /// Multistorey car park
+    /// </summary>
+    [EnumMember(Value = "PARKING_GARAGE")]
+    ParkingGarage = 21,
+
+    /// <summary>
+    /// A cleared area that is intended for parking vehicles,
+    /// i.e. at super markets, bars, etc.
+    /// </summary>
+    [EnumMember(Value = "PARKING_LOT")]
+    ParkingLot = 22,
+
+    /// <summary>
+    /// Multistorey car park, mainly underground.
+    /// </summary>
+    [EnumMember(Value = "UNDERGROUND_GARAGE")]
+    UndergroundGarage = 23,
+
+    //======================================
+
+    /// <summary>
+    /// Parking in public space.
+    /// </summary>
+    [EnumMember(Value = "OTHER")]
+    Other = 255,
+}

--- a/src/OCPI.Net.Validation/Validators/Location/OcpiLocationValidator.cs
+++ b/src/OCPI.Net.Validation/Validators/Location/OcpiLocationValidator.cs
@@ -56,6 +56,9 @@ internal partial class OcpiLocationValidator : ActionValidator<OcpiLocation>
         RuleForEach(x => x.RelatedLocations)
             .SetValidator(new OcpiAdditionalGeolocationValidator(actionType));
 
+        JsonRuleFor(x => x.Type)
+            .ValidEnum();
+
         JsonRuleFor(x => x.ParkingType)
             .ValidEnum();
 


### PR DESCRIPTION
Hi @YuriyDurov,
I've added the 2.1.1 properties to the OcpiLocation object.
I guess you would like to add validation to the new properties:

1. Validation that properties with different names on the 2 versions aren't both populated - for example, only one of max_amperage, amperage is populated. 

2. Validation of the string property's sizes according to version - for example the size of "id" property in 2.1.1 is string(39) and on 2.2.1 is string(36). 

3. Validation of enum values - some of the 2.1.1 enum types include less entries then on their 2.2.1 version.

I'm not familiar with the library validation infrastructure, so it was hard for me to conclude on how to do these validations - can you assist with that?

Thanks,
Lior
